### PR TITLE
Add smooth scroll support for zoom and album navigation

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -500,6 +500,9 @@
   "HZ_MEDIAVOLUME": {
     "message": "Default media volume (%)"
   },
+  "HZ_SMOOTHSCROLL": {
+    "message": "Smooth scroll support (trackpad / smooth-scroll mouse)"
+  },
   "HZ_SCROLLDELAY": {
     "message": "Scroll delay (ms)"
   },

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -1959,6 +1959,10 @@
             PVI.node = null;
             clearTimeout(PVI.timers.delayed_loader);
             win.removeEventListener("wheel", PVI.wheeler, true);
+            if (PVI._wheelRAF) { cancelAnimationFrame(PVI._wheelRAF); PVI._wheelRAF = null; }
+            PVI._wheelDeltaAccum = 0;
+            PVI._albumDeltaAccum = 0;
+            clearTimeout(PVI._albumDeltaTimer);
             PVI.DIV.style.display = PVI.LDR.style.display = "none";
             PVI.DIV.style.width = PVI.DIV.style.height = "0";
             PVI.CNT.removeAttribute("src");
@@ -2525,11 +2529,28 @@
 
             } else if (PVI.shouldScroll(e) && PVI.TRG.IMGS_album) {
                 if (d !== null) {
-                    if (cfg.hz.pileWheel === 2) {
-                        if (!e.deltaX && !e.wheelDeltaX) return;
-                        d = (e.deltaX || -e.wheelDeltaX) > 0;
-                    } else d = (e.deltaY || -e.wheelDelta) > 0;
-                    PVI.album(d ? 1 : -1, true);
+                    if (cfg.hz.smoothScroll) {
+                        var rawDelta;
+                        if (cfg.hz.pileWheel === 2) {
+                            if (!e.deltaX && !e.wheelDeltaX) return;
+                            rawDelta = e.deltaX || -e.wheelDeltaX || 0;
+                        } else {
+                            rawDelta = e.deltaY || -e.wheelDelta || 0;
+                        }
+                        PVI._albumDeltaAccum = (PVI._albumDeltaAccum || 0) + rawDelta;
+                        clearTimeout(PVI._albumDeltaTimer);
+                        PVI._albumDeltaTimer = setTimeout(function () { PVI._albumDeltaAccum = 0; }, 200);
+                        if (Math.abs(PVI._albumDeltaAccum) >= 80) {
+                            PVI.album(PVI._albumDeltaAccum > 0 ? 1 : -1, true);
+                            PVI._albumDeltaAccum = 0;
+                        }
+                    } else {
+                        if (cfg.hz.pileWheel === 2) {
+                            if (!e.deltaX && !e.wheelDeltaX) return;
+                            d = (e.deltaX || -e.wheelDeltaX) > 0;
+                        } else d = (e.deltaY || -e.wheelDelta) > 0;
+                        PVI.album(d ? 1 : -1, true);
+                    }
                 }
                 pdsp(e);
                 return;
@@ -2539,16 +2560,33 @@
                 return;
 
             } else if (PVI.fullZm && PVI.fullZm < 4) {
-                if (d !== null)
-                    PVI.resize(
-                        (e.deltaY || -e.wheelDelta) > 0 ? "-" : "+",
-                        PVI.fullZm > 1 ? (e.target === PVI.CNT ? [e.offsetX || e.layerX || 0, e.offsetY || e.layerY || 0] : []) : null
-                    );
+                if (d !== null) {
+                    if (cfg.hz.smoothScroll) {
+                        PVI._wheelDeltaAccum = (PVI._wheelDeltaAccum || 0) + (e.deltaY || -e.wheelDelta || 0);
+                        PVI._wheelLastXY = PVI.fullZm > 1 ? (e.target === PVI.CNT ? [e.offsetX || e.layerX || 0, e.offsetY || e.layerY || 0] : []) : null;
+                        if (!PVI._wheelRAF) {
+                            PVI._wheelRAF = requestAnimationFrame(PVI._applyAccumulatedZoom);
+                        }
+                    } else {
+                        PVI.resize(
+                            (e.deltaY || -e.wheelDelta) > 0 ? "-" : "+",
+                            PVI.fullZm > 1 ? (e.target === PVI.CNT ? [e.offsetX || e.layerX || 0, e.offsetY || e.layerY || 0] : []) : null
+                        );
+                    }
+                }
                 pdsp(e);
                 return;
             }
             PVI.lastScrollTRG = PVI.TRG;
             PVI.reset();
+        },
+
+        _applyAccumulatedZoom: function () {
+            PVI._wheelRAF = null;
+            var delta = PVI._wheelDeltaAccum || 0;
+            PVI._wheelDeltaAccum = 0;
+            if (delta === 0 || !PVI.fullZm) return;
+            PVI.resize(delta, PVI._wheelLastXY);
         },
 
         setCursor: function (cur) {
@@ -2604,6 +2642,31 @@
                     if (xy_img) {
                         xy_img[0] *= k[rot ? 1 : 0] - s[0];
                         xy_img[1] *= k[rot ? 0 : 1] - s[1];
+                    }
+                    break;
+                default:
+                    if (typeof x === "number") {
+                        k = [parseInt(PVI.DIV.style.width, 10), 0];
+                        k[1] = (k[0] * s[rot ? 0 : 1]) / s[rot ? 1 : 0];
+                        if (xy_img) {
+                            if (xy_img[1] === undefined || rot) {
+                                xy_img[0] = k[0] / 2;
+                                xy_img[1] = k[1] / 2;
+                            } else if (PVI.DIV.curdeg % 360)
+                                if (!(PVI.DIV.curdeg % 180)) {
+                                    xy_img[0] = k[0] - xy_img[0];
+                                    xy_img[1] = k[1] - xy_img[1];
+                                }
+                            xy_img[0] /= k[rot ? 1 : 0];
+                            xy_img[1] /= k[rot ? 0 : 1];
+                        }
+                        x = Math.max(0.25, Math.min(4, Math.exp(-x * 0.002877)));
+                        s[0] = x * Math.max(16, k[rot ? 1 : 0]);
+                        s[1] = x * Math.max(16, k[rot ? 0 : 1]);
+                        if (xy_img) {
+                            xy_img[0] *= k[rot ? 1 : 0] - s[0];
+                            xy_img[1] *= k[rot ? 0 : 1] - s[1];
+                        }
                     }
             }
             if (!xy_img) xy_img = [true, null];

--- a/src/data/defaults.json
+++ b/src/data/defaults.json
@@ -17,6 +17,7 @@
 		"hideIdleCursor": 500,
 		"history": true,
 		"mediaVolume": 40,
+		"smoothScroll": false,
 		"scrollDelay": 0,
 		"pileWheel": 1,
 		"pileCycle": false,

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -141,6 +141,14 @@
 				</span>
 			</div>
 
+			<div class="prow">
+				<label for="hz_smoothScroll" data-lng="HZ_SMOOTHSCROLL"></label>
+				<span>
+					<input id="hz_smoothScroll" name="hz_smoothScroll" type="checkbox">
+					<label for="hz_smoothScroll" class="checkbox"></label>
+				</span>
+			</div>
+
 			<div class="prow advanced">
 				<label for="hz_scrollDelay" data-lng="HZ_SCROLLDELAY"></label>
 				<span>


### PR DESCRIPTION
Fixes #52

## Problem

On macOS (and other systems) with trackpads or smooth-scrolling mice/tools (e.g. [Mos](https://mos.caldis.me/)), two scroll-based features break:

- **Zoom**: A single scroll gesture fires many small wheel events, each applying the full 4/3× or 0.75× zoom step. The image instantly becomes tiny or huge.
- **Album navigation**: Same issue — each wheel event advances one image, so a single gesture skips 5–10 images.

This happens because `wheeler()` calls `resize("+"/"-")` and `album(±1)` on every wheel event, using only the sign of `deltaY` and ignoring its magnitude.

## Solution

Adds an opt-in **"Smooth scroll support"** toggle in settings (off by default, so existing behavior is unchanged).

When enabled:

### Zoom (fullzoom mode)
- Wheel deltas are **accumulated over one animation frame** via `requestAnimationFrame`
- A single proportional zoom step is applied using `Math.exp(-delta × 0.002877)`
- The constant `0.002877` is calibrated so that a standard discrete mouse wheel click (`deltaY ≈ 100`) produces the same `4/3` / `0.75` ratios as before
- Trackpad gestures with smaller deltas produce proportionally smaller zoom steps
- Zoom factor is clamped to `[0.25, 4.0]` per frame to prevent extreme jumps

### Album navigation
- Wheel deltas are **accumulated until they cross a threshold of 80**
- A standard mouse wheel click (`deltaY ≈ 100`) crosses immediately — same as before
- Trackpad deltas accumulate gradually, advancing one image per natural gesture
- A 200ms timeout resets the accumulator if scrolling stops

## Files changed

| File | Change |
|------|--------|
| `src/content/content.js` | Conditional smooth scroll logic in `wheeler()`, new `_applyAccumulatedZoom()` method, numeric delta handling in `resize()`, state cleanup in `reset()` |
| `src/data/defaults.json` | New `smoothScroll: false` default |
| `src/options/options.html` | Checkbox for the toggle |
| `src/_locales/en/messages.json` | Label string for the toggle |

## Testing

1. **Toggle off** (default): verify zoom and album scroll work exactly as before with a regular mouse
2. **Toggle on + trackpad**: zoom should be smooth and proportional; album should advance one image per gesture
3. **Toggle on + discrete mouse wheel**: should feel the same as toggle off (~4/3 per click, 1 image per click)
4. **Zoom-to-cursor**: in drag mode (Shift+Enter), zoom should still center on cursor position

Full disclosure: This PR was created with the help of AI.