### PR TITLE
Fix right-button long-press full-zoom when `contextmenu` is swallowed

### DIFF
--- a/src/content/content.js
+++ b/src/content/content.js
@@ -104,7 +104,7 @@
         return null;
     };
 
-    var mdownstart, winW, winH, topWinW, topWinH;
+    var mdownstart, suppressRightContextMenu, rightPressMoved, winW, winH, topWinW, topWinH;
     var rgxHash = /#(?![?!].).*/;
     var rgxIsSVG = /\.svgz?$/i;
     // var rgxIsSVG = /\.svgz?$|^data:image\/svg/i;
@@ -122,6 +122,11 @@
     };
 
     var releaseFreeze = function (e) {
+        if (e.type === "mouseup" && e.button === 2) {
+            clearTimeout(PVI.timers.fz_press);
+            PVI.timers.fz_press = null;
+            rightPressMoved = false;
+        }
         if (typeof PVI.freeze === "number") {
             PVI.freeze = !cfg.hz.deactivate;
             return;
@@ -138,6 +143,56 @@
             return;
         }
         if (PVI.keyup_freeze_on) PVI.keyup_freeze();
+    };
+
+    var armRightPress = function (e) {
+        mdownstart = e.timeStamp;
+        PVI.md_x = e.clientX;
+        PVI.md_y = e.clientY;
+        suppressRightContextMenu = false;
+        rightPressMoved = false;
+
+        if (PVI.state > 2 && (cfg.hz.fzOnPress === 1 || cfg.hz.fzOnPress === 2) && !PVI.fullZm) {
+            clearTimeout(PVI.timers.cursor_hide);
+            clearTimeout(PVI.timers.cursor_wait);
+            const oldCursor = e.target.style.cursor;
+            e.target.style.cursor = "progress";
+            PVI.timers.cursor_wait = setTimeout(() => e.target.style.cursor = oldCursor, 300);
+        }
+        clearTimeout(PVI.timers.fz_press);
+        PVI.timers.fz_press = null;
+        if (PVI.state > 2 && cfg.hz.fzOnPress === 2 && !PVI.fullZm) {
+            PVI.timers.fz_press = setTimeout(function () {
+                if (!mdownstart || !cfg || cfg.hz.fzOnPress !== 2 || PVI.state <= 2 || PVI.fullZm) return;
+                if (rightPressMoved) return;
+                suppressRightContextMenu = true;
+                mdownstart = null;
+                PVI.key_action({ which: 13, shiftKey: false });
+            }, 320);
+        }
+    };
+
+    var onPointerDown = function (e) {
+        if (!cfg || !e.isTrusted || e.button !== 2) return;
+        if (e.pointerType && e.pointerType !== "mouse") return;
+        const root = doc.compatMode && doc.compatMode[0] === "B" ? doc.body : doc.documentElement;
+        if (e.clientX >= root.clientWidth || e.clientY >= root.clientHeight) return;
+        armRightPress(e);
+    };
+
+    var onPointerEnd = function (e) {
+        if (e.button !== 2) return;
+        clearTimeout(PVI.timers.fz_press);
+        PVI.timers.fz_press = null;
+        rightPressMoved = false;
+    };
+
+    var onPointerMove = function (e) {
+        if (typeof mdownstart !== "number") return;
+        if (!(e.buttons & 2)) return;
+        if (Math.abs(PVI.md_x - e.clientX) > 5 || Math.abs(PVI.md_y - e.clientY) > 5) {
+            rightPressMoved = true;
+        }
     };
 
     var onMouseDown = function (e) {
@@ -182,17 +237,7 @@
             PVI.keyup_freeze();
             PVI.freeze = PVI.freeze ? 1 : 0;
         }
-        mdownstart = e.timeStamp;
-        PVI.md_x = e.clientX;
-        PVI.md_y = e.clientY;
-
-        if (PVI.state > 2 && (cfg.hz.fzOnPress === 1 || cfg.hz.fzOnPress === 2) && !PVI.fullZm) {
-            clearTimeout(PVI.timers.cursor_hide);
-            clearTimeout(PVI.timers.cursor_wait);
-            const oldCursor = e.target.style.cursor;
-            e.target.style.cursor = "progress";
-            PVI.timers.cursor_wait = setTimeout(() => e.target.style.cursor = oldCursor, 300);
-        }
+        armRightPress(e);
 
         if (e.target.href || e.target.parentNode?.href) {
             e.preventDefault();
@@ -200,6 +245,13 @@
     };
 
     var onContextMenu = function (e) {
+        clearTimeout(PVI.timers.fz_press);
+        PVI.timers.fz_press = null;
+        if (suppressRightContextMenu) {
+            suppressRightContextMenu = false;
+            pdsp(e);
+            return;
+        }
         if (!mdownstart || e.button !== 2 || PVI.md_x !== e.clientX || PVI.md_y !== e.clientY) {
             if (mdownstart) mdownstart = null;
 
@@ -1985,6 +2037,10 @@
             if (PVI.iFrame) win.parent.postMessage({ vdfDpshPtdhhd: "from_frame", reset: true }, "*");
             if (PVI.state) win.removeEventListener("mousemove", PVI.m_move, true);
             PVI.node = null;
+            clearTimeout(PVI.timers.fz_press);
+            PVI.timers.fz_press = null;
+            suppressRightContextMenu = false;
+            rightPressMoved = false;
             clearTimeout(PVI.timers.delayed_loader);
             win.removeEventListener("wheel", PVI.wheeler, true);
 
@@ -3294,6 +3350,10 @@
             doc.documentElement[e]("mouseleave", PVI.m_leave, false);
             doc[e]("visibilitychange", PVI.onVisibilityChange, true);
             win[e]("contextmenu", onContextMenu, true);
+            win[e]("pointerdown", onPointerDown, true);
+            win[e]("pointermove", onPointerMove, true);
+            win[e]("pointerup", onPointerEnd, true);
+            win[e]("pointercancel", onPointerEnd, true);
             win[e]("mouseover", PVI.m_over, true);
             win[e]("mousedown", onMouseDown, true);
             win[e]("mouseup", releaseFreeze, true);


### PR DESCRIPTION
# Fix right-button long-press full-zoom when `contextmenu` is swallowed

## Summary
This PR fixes a regression where right-button long-press did not enter full-zoom and the browser context menu opened instead.

It specifically addresses extension conflicts (notably ScrollAnywhere) that suppress `contextmenu` and/or `mousedown`, preventing Imagus from receiving its original right-click trigger path.

## Root cause
- Long-press full-zoom depended on `contextmenu`/`mousedown` events reaching Imagus.
- ScrollAnywhere can intercept those events first and stop propagation.
- When intercepted, Imagus never executed its long-press branch.

## Changes
- Added a minimal pointer-based fallback in `src/content/content.js`:
  - arm right-press state on `pointerdown` (capture phase, mouse only)
  - start `fz_press` timer for `fzOnPress === 2` (long-press)
  - trigger full-zoom directly if hold duration is met
- Added `pointermove` tracking to cancel fallback when movement exceeds 5px.
- Added `suppressRightContextMenu` so if fallback already triggered full-zoom, the subsequent context menu is prevented.
- Added cleanup for the new timer/flags on `mouseup` / `pointerup` / `pointercancel` and in `reset()`.

## Compatibility notes
- Existing `onContextMenu` behavior is preserved (only a small early-return suppression branch was added).
- Behavior is preserved for regular right-click and existing `fzOnPress` semantics:
  - `fzOnPress = click` still uses quick-press semantics
  - `fzOnPress = long-press` now works even if `contextmenu` is swallowed by another extension
- Right-button drag branch (`actTrigger === "m2"`) remains intact.

## Manual test plan
1. With ScrollAnywhere disabled:
   - `fzOnPress = long-press`: hold right button on active popup target, verify full-zoom enters.
2. With ScrollAnywhere enabled:
   - Repeat long-press test, verify full-zoom still enters.
3. Movement checks (with ScrollAnywhere enabled):
   - small movement (1-3px) still treated as long-press hold
   - larger movement (>5px) should not trigger long-press fallback
4. Regression checks:
   - `fzOnPress = click` still behaves as before
   - keyboard context-menu key still opens native menu where expected
   - non-Imagus pages/interactions keep default context menu behavior

## Files changed
- `src/content/content.js`
