### PR TITLE
Change cursor style from 'zoom-in' to 'help'

### DIFF
--- a/src/content/content.js
+++ b/src/content/content.js
@@ -2861,7 +2861,7 @@
                 if (cfg.hz.markOnHovered && (isFrozen || cfg.hz.delay >= 25))
                     if (cfg.hz.markOnHovered === "cr" || cfg.hz.markOnHovered === "both") {
                         PVI.lastTRGStyle.cursor = trg.style.cursor;
-                        trg.style.cursor = "zoom-in";
+                        trg.style.cursor = "help";
                     }
                     if (cfg.hz.markOnHovered === "styled" || cfg.hz.markOnHovered === "both") {
                         PVI.showHVR(true);
@@ -2956,7 +2956,7 @@
                 if (PVI.shouldScroll(e) && (PVI.TRG.IMGS_album || PVI.isVideo() && (!cfg.hz.scrollVideoWithCtrl || e?.ctrlKey))) {
                     PVI.setCursor();
                 } else if (e?.target) {
-                    PVI.setCursor("zoom-in");
+                    PVI.setCursor("help");
                 }
                 // that's keydown event
                 if (e?.target && !e.clientX) {


### PR DESCRIPTION
The 'zoom-in' cursor can't be customized in Windows. If you have the 'change cursor' option enabled in Imagus-Reborn, it shows a pixelated magnifying glass when you hover over images. This looks very out of place with the rest of the customized cursors. The "help" cursor is able to be customized and aligns with the cursor pack.