### PR TITLE
pushd and popd in the build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,17 +13,17 @@ rm -rf ./build/* || die
 echo -e "\nCopying '$src' to 'chrome'..."
 cp -r ./$src/. ./build/chrome/ || die
 echo "Zipping the Chrome build..."
-cd ./build/chrome || die
+pushd ./build/chrome || die
 rm -f manifest_firefox.json || die
 zip -9 -q -r ../ImagusReborn_Chrome_v`sed -n -E 's/^.*"version":\s*"(\S*)".*/\1/p' manifest.json`.zip *
+popd
 
-cd ../..
 echo -e "\nCopying '$src' to 'firefox'..."
 cp -r ./$src/. ./build/firefox/ || die
 echo "Zipping the Firefox build..."
-cd ./build/firefox || die
+pushd ./build/firefox || die
 mv -f manifest_firefox.json manifest.json
 zip -9 -q -r ../ImagusReborn_Firefox_v`sed -n -E 's/^.*"version":\s*"(\S*)".*/\1/p' manifest.json`.zip *
+popd
 
 echo -e "\nDone!"
-waitkey


### PR DESCRIPTION
Minor improvement. For a script that's this small it doesn't matter much, but in general to enter and return from a directory it's better to use pushd/popd than cd.

I also removed the ending call to waitkey when the script finishes without error. Does not seem useful to wait on input on success.