### PR TITLE
Remove the transition on the outline

### DIFF
--- a/src/content/content.js
+++ b/src/content/content.js
@@ -542,7 +542,6 @@
                 height: 0px;
                 padding: 0;
                 margin: 0;
-                transition: all .1s cubic-bezier(0, 1, 0.3, 1), opacity .1s ease-in;
                 ${cfg.hz.hoverCss || ""}
             `;
 


### PR DESCRIPTION
`transition: all .1s cubic-bezier(0, 1, 0.3, 1), opacity .1s ease-in;` was causing me problems when scrolling, particularly with touchpads. The fade would make the outline sort of linger in an unusual way in some cases, before fading out.

It would be better to not hard-code the CSS transition, especially since the outline is otherwise accepting of custom CSS. The transition, rightfully, belongs in the custom CSS field.