### PR TITLE
Add hover media loop preference with default/always/never options

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -506,6 +506,18 @@
   "HZ_MEDIAVOLUME": {
     "message": "Default media volume (%)"
   },
+  "HZ_MEDIALOOP": {
+    "message": "Media looping behavior"
+  },
+  "HZ_MEDIALOOP_DEFAULT": {
+    "message": "Default (loop short/unknown media)"
+  },
+  "HZ_MEDIALOOP_ALWAYS": {
+    "message": "Always loop"
+  },
+  "HZ_MEDIALOOP_NEVER": {
+    "message": "Never loop"
+  },
   "HZ_SMOOTHSCROLL": {
     "message": "Smooth scroll support (trackpad / smooth-scroll mouse)"
   },

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -1806,7 +1806,16 @@
                 PVI.VID.naturalWidth = PVI.VID.videoWidth || 300;
                 PVI.VID.naturalHeight = PVI.VID.videoHeight || 40;
                 PVI.VID.audio = !PVI.VID.videoHeight;
-                PVI.VID.loop = !PVI.VID.duration || PVI.VID.duration <= 60;
+                switch (cfg.hz.mediaLoop) {
+                    case "always":
+                        PVI.VID.loop = true;
+                        break;
+                    case "never":
+                        PVI.VID.loop = false;
+                        break;
+                    default:
+                        PVI.VID.loop = !PVI.VID.duration || PVI.VID.duration <= 60;
+                }
                 if (PVI.VID.audio) {
                     PVI.VID._controls = PVI.VID.controls;
                     PVI.VID.controls = true;

--- a/src/data/defaults.json
+++ b/src/data/defaults.json
@@ -18,6 +18,7 @@
 		"hideIdleCursor": 500,
 		"history": true,
 		"mediaVolume": 40,
+		"mediaLoop": "default",
 		"smoothScroll": true,
 		"scrollDelay": 0,
 		"pileWheel": 1,

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -142,6 +142,17 @@
 			</div>
 
 			<div class="prow">
+				<label for="hz_mediaLoop" data-lng="HZ_MEDIALOOP"></label>
+				<span>
+					<select id="hz_mediaLoop" name="hz_mediaLoop">
+						<option value="default" selected data-lng="HZ_MEDIALOOP_DEFAULT"></option>
+						<option value="always" data-lng="HZ_MEDIALOOP_ALWAYS"></option>
+						<option value="never" data-lng="HZ_MEDIALOOP_NEVER"></option>
+					</select>
+				</span>
+			</div>
+
+			<div class="prow">
 				<label for="hz_smoothScroll" data-lng="HZ_SMOOTHSCROLL"></label>
 				<span>
 					<input id="hz_smoothScroll" name="hz_smoothScroll" type="checkbox" checked>


### PR DESCRIPTION
No controls for media looping currently exist – this PR adds a select defaulting to the existing behaviour, and adding `always` and `never` options.