### PR TITLE
Fix SPA

### DIFF
--- a/src/background/service.js
+++ b/src/background/service.js
@@ -823,6 +823,10 @@ chrome.action.onClicked.addListener(toggleTab);
 
 // update badge on tab update
 chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
+    if (changeInfo.url) {
+        chrome.tabs.sendMessage(tabId, { cmd: "reinit" }).catch(() => {});
+    }
+
     if (!tab.active) return;
     updateBadge(tabId, tab.url);
 });


### PR DESCRIPTION
If we open both links in new tabs with grant rules below, the first one will have Imagus disabled, even if you visit any `https://www.fanatical.com/en/game/*` links, while the second one will have Imagus enabled everywhere.

**Links:**
https://www.fanatical.com/en/
https://www.fanatical.com/en/game/pragmata

**Grant rules:**
```
!:fanatical.com
~~:^https://(?:www\.)?fanatical\.com/en/game/[^/]+(?:/|$)
```